### PR TITLE
feat: Authenticate clients on registration to protect `playerID`s

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,7 @@ class P2PHost {
   private clients: Map<Client, Client> = new Map();
   private matchID: string;
   private master: Master;
+  private db: P2PDB;
 
   constructor({
     game,
@@ -80,10 +81,10 @@ class P2PHost {
       throw new Error("setupData Error: " + match.setupDataError);
     }
 
-    const db = new P2PDB();
-    db.createMatch(this.matchID, match);
+    this.db = new P2PDB();
+    this.db.createMatch(this.matchID, match);
 
-    this.master = new Master(game, db, {
+    this.master = new Master(game, this.db, {
       send: ({ playerID, ...data }) => {
         for (const [client] of this.clients) {
           if (client.metadata.playerID === playerID) client.send(data);

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,9 +100,49 @@ class P2PHost {
   }
 
   registerClient(client: Client): void {
+    const isAuthenticated: boolean = this.authenticateClient(client);
+    // If the client failed to authenticate, don’t register it.
+    if (!isAuthenticated) return;
     const { playerID, credentials } = client.metadata;
     this.clients.set(client, client);
     this.master.onConnectionChange(this.matchID, playerID, credentials, true);
+  }
+
+  /**
+   * Store a player’s credentials on initial connection and authenticate them subsequently.
+   * @param client Client to authenticate.
+   * @returns `true` if the client was successfully authenticated, `false` if it wasn’t.
+   */
+  private authenticateClient(client: Client): boolean {
+    const { playerID, credentials } = client.metadata;
+    const { metadata } = this.db.fetch(this.matchID);
+
+    // Spectators provide null/undefined playerIDs and don’t need authenticating.
+    if (
+      playerID === null ||
+      playerID === undefined ||
+      !(+playerID in metadata.players)
+    ) {
+      return true;
+    }
+
+    const existingCredentials = metadata.players[+playerID].credentials;
+
+    // If no credentials exist yet for this player, store those
+    // provided by the connecting client and authenticate.
+    if (!existingCredentials && credentials) {
+      this.db.setMetadata(this.matchID, {
+        ...metadata,
+        players: {
+          ...metadata.players,
+          [+playerID]: { ...metadata.players[+playerID], credentials },
+        },
+      });
+      return true;
+    }
+
+    // If credentials match (or credentials are neither provided nor stored), authenticate.
+    return credentials === existingCredentials;
   }
 
   unregisterClient(client: Client): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -141,7 +141,10 @@ class P2PHost {
       return true;
     }
 
-    // If credentials match (or credentials are neither provided nor stored), authenticate.
+    // If credentials are neither provided nor stored, authenticate.
+    if (!existingCredentials && !credentials) return true;
+
+    // If credentials match, authenticate.
     return credentials === existingCredentials;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ interface Client {
   send: Peer.DataConnection["send"];
   metadata: {
     playerID: PlayerID | null;
+    credentials: string | undefined;
   };
 }
 
@@ -99,13 +100,9 @@ class P2PHost {
   }
 
   registerClient(client: Client): void {
+    const { playerID, credentials } = client.metadata;
     this.clients.set(client, client);
-    this.master.onConnectionChange(
-      this.matchID,
-      client.metadata.playerID,
-      undefined,
-      true
-    );
+    this.master.onConnectionChange(this.matchID, playerID, credentials, true);
   }
 
   unregisterClient(client: Client): void {
@@ -154,7 +151,7 @@ class P2PTransport extends Transport {
 
   connect(): void {
     const hostID = this.namespacedPeerID();
-    const metadata = { playerID: this.playerID };
+    const metadata = { playerID: this.playerID, credentials: this.credentials };
 
     this.peer = new Peer(this.isHost ? hostID : undefined, this.peerOptions);
 


### PR DESCRIPTION
Closes #1

Unsafe usage without credentials continues to be possible, but this adds support for using the standard boardgame.io `credentials` to add some measure of protection to individual `playerID`s.

When a client connects, claiming a `playerID`, their `credentials` will also be sent. If they are the first client to connect for the given `playerID`, their `credentials` will be stored in match metadata by the host (like on the server). Subsequent requests to connect for that `playerID` must then provide those same `credentials` to register successfully.