### PR TITLE
fix: send close event on window close

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -161,6 +161,7 @@ class P2PTransport extends Transport {
         host.registerClient(client);
         client.on("data", (data) => void host.processAction(data));
         client.on("close", () => void host.unregisterClient(client));
+        window && window.addEventListener("beforeunload", () => client.close());
       });
       this.peer.on("error", this.onError);
 
@@ -187,6 +188,7 @@ class P2PTransport extends Transport {
     host.on("open", () => void this.onConnect());
     // Apply updates received from the host.
     host.on("data", (data) => void this.notifyClient(data));
+    window && window.addEventListener("beforeunload", () => host.close());
   }
 
   /** Execute tasks once the connection to a remote or local host has been established. */


### PR DESCRIPTION
According to [https://github.com/peers/peerjs/issues/58](url), peerjs `DataConnection` won't close until you manually call `conn.close()`. Master should receive a `close` message (which currently doesn't) when a player closes his browser window.