### PR TITLE
fixed: RegExp error in Safari

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -104,10 +104,9 @@ class P2PTransport extends Transport {
     if (!this.matchID) throw new Error("matchID must be provided");
     // Sanitize host ID for PeerJS: remove any non-alphanumeric characters, trim
     // leading/trailing hyphens/underscores and collapse consecutive hyphens/underscores.
-    return `boardgameio-${this.gameName}-matchid-${this.matchID}`.replace(
-      /([^A-Za-z0-9_-]|^[_-]+|[_-]+$|(?<=[_-])[_-]+)/g,
-      ""
-    );
+    return `boardgameio-${this.gameName}-matchid-${this.matchID}`
+      .replace(/([^A-Za-z0-9_-]|^[_-]+|[_-]+$)/g, "")
+      .replace(/([_-])[_-]+/g, "$1");
   }
 
   /** Keep credentials and encryption keys in sync. */

--- a/test/p2p.test.ts
+++ b/test/p2p.test.ts
@@ -16,4 +16,15 @@ describe("P2P", () => {
       client.stop();
     }).not.toThrow();
   });
+
+  test("will sanitize matchid for peerjs", () => {
+    const game = { name: "test" };
+    const matchID = "-_-ABC---def01%2&3_-_";
+    const multiplayer = P2P();
+    const client = Client({ game, matchID, multiplayer });
+    client.start();
+    expect((client as any).transport.hostID).toBe(
+      "boardgameio-test-matchid-ABC-def0123"
+    );
+  });
 });


### PR DESCRIPTION
Missing lookbehind support in Safari's RegExp impl results in browser error