### PR TITLE
Add plumbing for player name and data properties of matchData

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1586,23 +1586,6 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.52.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.52.0.tgz",
-      "integrity": "sha512-AR7sxxfBKiNV0FWBSARxM8DmNxrwgnYMPwmpkC1Pl1n+eT8/I2NAUPuwDy/FmDcC6F8pBfmOcaxcxRHspgOBMw==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.52.0",
-        "@typescript-eslint/visitor-keys": "5.52.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
     "node_modules/@typescript-eslint/type-utils": {
       "version": "5.53.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.53.0.tgz",
@@ -1685,46 +1668,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/types": {
-      "version": "5.52.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.52.0.tgz",
-      "integrity": "sha512-oV7XU4CHYfBhk78fS7tkum+/Dpgsfi91IIDy7fjCyq2k6KB63M6gMC0YIvy+iABzmXThCRI6xpCEyVObBdWSDQ==",
-      "dev": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.52.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.52.0.tgz",
-      "integrity": "sha512-WeWnjanyEwt6+fVrSR0MYgEpUAuROxuAH516WPjUblIrClzYJj0kBbjdnbQXLpgAN8qbEuGywiQsXUVDiAoEuQ==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.52.0",
-        "@typescript-eslint/visitor-keys": "5.52.0",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "semver": "^7.3.7",
-        "tsutils": "^3.21.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
       }
     },
     "node_modules/@typescript-eslint/utils": {
@@ -1817,23 +1760,6 @@
       "dev": true,
       "dependencies": {
         "@typescript-eslint/types": "5.53.0",
-        "eslint-visitor-keys": "^3.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.52.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.52.0.tgz",
-      "integrity": "sha512-qMwpw6SU5VHCPr99y274xhbm+PRViK/NATY6qzt+Et7+mThGuFSl/ompj2/hrBlRP/kq+BFdgagnOSgw9TB0eA==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.52.0",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -9657,16 +9583,6 @@
         }
       }
     },
-    "@typescript-eslint/scope-manager": {
-      "version": "5.52.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.52.0.tgz",
-      "integrity": "sha512-AR7sxxfBKiNV0FWBSARxM8DmNxrwgnYMPwmpkC1Pl1n+eT8/I2NAUPuwDy/FmDcC6F8pBfmOcaxcxRHspgOBMw==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/types": "5.52.0",
-        "@typescript-eslint/visitor-keys": "5.52.0"
-      }
-    },
     "@typescript-eslint/type-utils": {
       "version": "5.53.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.53.0.tgz",
@@ -9710,27 +9626,6 @@
             "eslint-visitor-keys": "^3.3.0"
           }
         }
-      }
-    },
-    "@typescript-eslint/types": {
-      "version": "5.52.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.52.0.tgz",
-      "integrity": "sha512-oV7XU4CHYfBhk78fS7tkum+/Dpgsfi91IIDy7fjCyq2k6KB63M6gMC0YIvy+iABzmXThCRI6xpCEyVObBdWSDQ==",
-      "dev": true
-    },
-    "@typescript-eslint/typescript-estree": {
-      "version": "5.52.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.52.0.tgz",
-      "integrity": "sha512-WeWnjanyEwt6+fVrSR0MYgEpUAuROxuAH516WPjUblIrClzYJj0kBbjdnbQXLpgAN8qbEuGywiQsXUVDiAoEuQ==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/types": "5.52.0",
-        "@typescript-eslint/visitor-keys": "5.52.0",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "semver": "^7.3.7",
-        "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/utils": {
@@ -9790,16 +9685,6 @@
             "eslint-visitor-keys": "^3.3.0"
           }
         }
-      }
-    },
-    "@typescript-eslint/visitor-keys": {
-      "version": "5.52.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.52.0.tgz",
-      "integrity": "sha512-qMwpw6SU5VHCPr99y274xhbm+PRViK/NATY6qzt+Et7+mThGuFSl/ompj2/hrBlRP/kq+BFdgagnOSgw9TB0eA==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/types": "5.52.0",
-        "eslint-visitor-keys": "^3.3.0"
       }
     },
     "abab": {

--- a/src/host.ts
+++ b/src/host.ts
@@ -80,8 +80,11 @@ export class P2PHost {
 
     // Update the match data with extra server properties
     if (playerID) {
-      metadata.players[parseInt(playerID)].name = playerName;
-      metadata.players[parseInt(playerID)].data = playerData;
+      const parsedID = Number.parseInt(playerID);
+      if (metadata.players[parsedID]) {
+        metadata.players[parsedID].name = playerName;
+        metadata.players[parsedID].data = playerData;
+      }
     }
 
     this.master.onConnectionChange(this.matchID, playerID, credentials, true);

--- a/src/host.ts
+++ b/src/host.ts
@@ -73,8 +73,17 @@ export class P2PHost {
     const isAuthenticated: boolean = this.authenticateClient(client);
     // If the client failed to authenticate, don’t register it.
     if (!isAuthenticated) return;
-    const { playerID, credentials } = client.metadata;
+    const { playerID, credentials, playerName, playerData } = client.metadata;
     this.clients.set(client, client);
+
+    const { metadata } = this.db.fetch(this.matchID);
+
+    // Update the match data with extra server properties
+    if (playerID) {
+      metadata.players[parseInt(playerID)].name = playerName;
+      metadata.players[parseInt(playerID)].data = playerData;
+    }
+
     this.master.onConnectionChange(this.matchID, playerID, credentials, true);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,8 @@ type PeerError = Error & {
 };
 
 interface P2POpts {
+  playerName?: string;
+  playerData?: any;
   isHost?: boolean;
   peerOptions?: PeerJSOption;
   onError?: (error: PeerError) => void;
@@ -82,6 +84,8 @@ class P2PTransport extends Transport {
   private emit?: (data: ClientAction) => void;
   private retryHandler: BackoffScheduler;
   private privateKey?: string;
+  private playerName?: string;
+  private playerData?: any;
 
   constructor({
     isHost,
@@ -97,6 +101,8 @@ class P2PTransport extends Transport {
     this.game = opts.game;
     this.retryHandler = new BackoffScheduler();
     this.setCredentials(opts.credentials);
+    this.playerName = opts.playerName;
+    this.playerData = opts.playerData;
   }
 
   /** Synthesized peer ID for looking up this match’s host. */
@@ -127,6 +133,8 @@ class P2PTransport extends Transport {
     return {
       playerID: this.playerID,
       credentials: this.credentials,
+      playerName: this.playerName,
+      playerData: this.playerData,
       message:
         this.playerID && this.privateKey
           ? signMessage(this.playerID, this.privateKey)

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,8 @@ export interface Client {
     playerID: PlayerID | null;
     credentials: string | undefined;
     message?: string;
+    playerName?: string;
+    playerData?: any;
   };
 }
 


### PR DESCRIPTION
When joining a game through the lobby API ([docs](https://github.com/boardgameio/boardgame.io/blob/main/docs/documentation/api/Lobby.md#joining-a-match)) you can can provide a playerName and arbitrary data object that get associated with the player and can be accessed on the client through the `matchData` property.

This change adds plumbing to the P2P implementation so that when creating the P2P instance you can provide the playerName and data values to get passed along like they would in the lobby API.