### PR TITLE
fix: import peerjs correctly (for esinstall to work)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import Peer from "peerjs";
+import { Peer } from "peerjs";
 import type { PeerJSOption } from "peerjs";
 import { sign, hash } from "tweetnacl";
 import { decodeUTF8, encodeBase64 } from "tweetnacl-util";


### PR DESCRIPTION
esinstall fails with the current version of p2p, because it imports Peer as default, whereas the official site doc states otherwise (see https://github.com/peers/peerjs usage). With this fix, esinstall works